### PR TITLE
Development environment setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.vagrant

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,9 @@ RUN adduser mezuro sudo
 ENV NOTVISIBLE "in users profile"
 RUN echo "export VISIBLE=now" >> /etc/profile
 
+# Install python in order to get ansible working
+RUN apt-get update && apt-get -y install python
+
 EXPOSE 22
 
 ENTRYPOINT ["/lib/systemd/systemd"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,17 +2,45 @@
 
 FROM ubuntu:16.04
 
+# Update the system
 RUN apt-get update && apt-get upgrade -y
+
+# Systemd, from: https://github.com/dockerimages/docker-systemd/blob/master/15.10/Dockerfile
+RUN apt-get update && apt-get install systemd && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN cd /lib/systemd/system/sysinit.target.wants/; ls | grep -v systemd-tmpfiles-setup | xargs rm -f $1 \
+rm -f /lib/systemd/system/multi-user.target.wants/*;\
+rm -f /etc/systemd/system/*.wants/*;\
+rm -f /lib/systemd/system/local-fs.target.wants/*; \
+rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
+rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+rm -f /lib/systemd/system/basic.target.wants/*;\
+rm -f /lib/systemd/system/anaconda.target.wants/*; \
+rm -f /lib/systemd/system/plymouth*; \
+rm -f /lib/systemd/system/systemd-update-utmp*;
+RUN systemctl set-default multi-user.target
+ENV init /lib/systemd/systemd
+VOLUME [ "/sys/fs/cgroup" ]
+
 RUN apt-get update && apt-get install -y openssh-server
-RUN mkdir /var/run/sshd
+#RUN mkdir /var/run/sshd
 RUN echo 'root:mezuro' | chpasswd
 RUN sed -i 's/PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
 
 # SSH login fix. Otherwise user is kicked off after login
 RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
 
+# Set sudo
+RUN apt-get update && apt-get -y install sudo
+
+# Set mezuro user
+RUN useradd -ms /bin/bash mezuro
+RUN echo 'mezuro:mezuro' | chpasswd
+RUN adduser mezuro sudo
+
 ENV NOTVISIBLE "in users profile"
 RUN echo "export VISIBLE=now" >> /etc/profile
 
 EXPOSE 22
-CMD ["/usr/sbin/sshd", "-D"]
+
+ENTRYPOINT ["/lib/systemd/systemd"]
+CMD ["systemd.unit=emergency.service"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# NOTICE: This is intended to be an base for Vagrant
+
+FROM ubuntu:16.04
+
+RUN apt-get update && apt-get upgrade -y
+RUN apt-get update && apt-get install -y openssh-server
+RUN mkdir /var/run/sshd
+RUN echo 'root:mezuro' | chpasswd
+RUN sed -i 's/PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
+
+# SSH login fix. Otherwise user is kicked off after login
+RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
+
+ENV NOTVISIBLE "in users profile"
+RUN echo "export VISIBLE=now" >> /etc/profile
+
+EXPOSE 22
+CMD ["/usr/sbin/sshd", "-D"]

--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ Ansible playbooks for setting up the mezuro.org services
 
 `ansible all -m ping -u <USERNAME>`
 
+## Development
+
+The environment is based on Docker within Vagrant.
+
+`vagrant up --provider docker`
+
 ## License
 
 This is licensed under GPLv3 (see COPYING file) by the AUTHORS (see AUTHORS file).

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -18,6 +18,7 @@ Vagrant.configure("2") do |config|
   config.ssh.username = 'root'
   config.ssh.password = 'mezuro'
 
+  # Otherwise you can only ssh as root
   config.vm.provision "shell", inline: 'systemctl start systemd-user-sessions.service'
 
   config.vm.define "prezento" do |prezento|
@@ -25,12 +26,12 @@ Vagrant.configure("2") do |config|
     prezento.vm.network "forwarded_port", guest: 8085, host: 50085
   end
 
-  config.vm.define "postgresql" do |prezento|
-    prezento.vm.network "forwarded_port", guest: 22, host: 50122
+  config.vm.define "postgresql" do |postgresql|
+    postgresql.vm.network "forwarded_port", guest: 22, host: 50122
   end
 
-  config.vm.define "kalibro" do |prezento|
-    prezento.vm.network "forwarded_port", guest: 22, host: 50222, id: 'ssh'
+  config.vm.define "kalibro" do |kalibro|
+    kalibro.vm.network "forwarded_port", guest: 22, host: 50222, id: 'ssh'
   end
 
   # The most common configuration options are documented and commented below.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,86 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  config.vm.define "prezento"
+    # See https://www.vagrantup.com/docs/provisioning/docker.html for more info
+    config.vm.provider "docker" do |d|
+      d.build_dir = '.'
+      d.build_args = '--tag=sshd_ubuntu'
+      d.ports ["50022:22", "8085:8085"]
+    end
+  end
+
+  #config.vm.provision "docker" do |d|
+  #  d.build_image ".", args: '-t sshd-ubuntu'
+  #  #d.build_dir '.'
+  #  d.run "sshd-ubuntu"
+  #end
+
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://atlas.hashicorp.com/search.
+  # config.vm.box = "base"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+  # end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Define a Vagrant Push strategy for pushing to Atlas. Other push strategies
+  # such as FTP and Heroku are also available. See the documentation at
+  # https://docs.vagrantup.com/v2/push/atlas.html for more information.
+  # config.push.define "atlas" do |push|
+  #   push.app = "YOUR_ATLAS_USERNAME/YOUR_APPLICATION_NAME"
+  # end
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  # config.vm.provision "shell", inline: <<-SHELL
+  #   apt-get update
+  #   apt-get install -y apache2
+  # SHELL
+end

--- a/hosts
+++ b/hosts
@@ -2,3 +2,12 @@
 prezento ansible_host='mezuro.org' ansible_port=10101
 postgresql ansible_ssh_common_args='-o ProxyCommand="ssh -W %h:%p -q mezuro.org -p 10101"' ansible_host=172.24.1.12
 kalibro ansible_ssh_common_args='-o ProxyCommand="ssh -W %h:%p -q mezuro.org -p 10101"' ansible_host=172.24.1.13
+
+[dev.mezuro.org]
+prezento-dev ansible_port=50022
+postgresql-dev ansible_port=50122
+kalibro-dev ansible_port=50222
+
+[dev.mezuro.org:vars]
+ansible_host='localhost'
+ansible_user='mezuro'


### PR DESCRIPTION
Defines an `Dockerfile` which:
- Installs Ubuntu 16.04
- Setup systemd on it
- Setup an ssh accessible server
- Set properly an user

The `Vagrantfile` complements the `Dockerfile` by:
- Properly building the container image
- Setting up run args and volumes required by systemd
- Adjusts users and password to the ones available within the container
- Brings up missing systemd services

And has its own features:
- Setting port forwards
- Brings up multiple containers that replicate the mezuro.org environment

Finally the `hosts` file is setup to use those newly created hosts.
